### PR TITLE
Adiciona regra Cursor de vínculo organizacional com o Jira (PUNK)

### DIFF
--- a/.cursor/rules/jira-projetos-organizacionais.mdc
+++ b/.cursor/rules/jira-projetos-organizacionais.mdc
@@ -20,7 +20,7 @@ Fonte canônica: `company-ops` → `config/jira-projects.yml` + `config/jira-bac
 | Igreja 4.0 | I40 | `igreja4.0` |
 | Studio & Style | STUD | `studio-style` |
 | Gamers League | GL | `cs-league` |
-| Finanças Auto | FIN | `financas-news` |
+| Finanças News | FN | `financas-news` |
 | Company Ops | OPS | `company-ops` |
 | Punk Code Landing | PUNK | `punk-code-landing-page` |
 

--- a/.cursor/rules/jira-projetos-organizacionais.mdc
+++ b/.cursor/rules/jira-projetos-organizacionais.mdc
@@ -1,0 +1,32 @@
+---
+description: Parametro organizacional Jira - produtos Punk Code Solution
+alwaysApply: true
+---
+
+# Projetos organizacionais (Jira)
+
+Site: https://punk-code-solution.atlassian.net  
+Cloud ID: `47d83d01-d30e-44d9-8cab-7b022de9051d`
+
+Este repositório mapeia para a key **PUNK** (landing institucional).
+
+Fonte canônica: `company-ops` → `config/jira-projects.yml` + `config/jira-backlog.json`.
+
+## Mapeamento (organização)
+
+| Projeto | Key | Repo |
+|---|---|---|
+| Pronto | PRON | `mobileapp` |
+| Igreja 4.0 | I40 | `igreja4.0` |
+| Studio & Style | STUD | `studio-style` |
+| Gamers League | GL | `cs-league` |
+| Finanças Auto | FIN | `financas-news` |
+| Company Ops | OPS | `company-ops` |
+| Punk Code Landing | PUNK | `punk-code-landing-page` |
+
+## Regras de trabalho
+
+1. Consultar e atualizar issues **PUNK-*** existentes antes de criar novas (há histórico de branches `PUNK-*` no Git).
+2. Ao avançar fases, mover no Jira via Atlassian MCP (`transitionJiraIssue`).
+3. Fluxo: **Aberta → Desenvolvimento → Teste → Concluido**.
+4. Usar sempre o projeto **PUNK** neste repositório.

--- a/.cursor/rules/jira-projetos-organizacionais.mdc
+++ b/.cursor/rules/jira-projetos-organizacionais.mdc
@@ -1,18 +1,18 @@
 ---
-description: Parametro organizacional Jira - produtos Punk Code Solution
+description: Política global Jira — vínculo obrigatório, fluxo e hierarquia
 alwaysApply: true
 ---
 
-# Projetos organizacionais (Jira)
+# Política global Jira (Punk Code Solution)
 
 Site: https://punk-code-solution.atlassian.net  
 Cloud ID: `47d83d01-d30e-44d9-8cab-7b022de9051d`
 
-Este repositório mapeia para a key **PUNK** (landing institucional).
+Este repositório mapeia para a key **PUNK** (Punk Code Landing).
 
-Fonte canônica: `company-ops` → `config/jira-projects.yml` + `config/jira-backlog.json`.
+Fonte canônica: `company-ops` → `config/jira-projects.yml`.
 
-## Mapeamento (organização)
+## Mapeamento projeto ↔ key
 
 | Projeto | Key | Repo |
 |---|---|---|
@@ -24,9 +24,53 @@ Fonte canônica: `company-ops` → `config/jira-projects.yml` + `config/jira-bac
 | Company Ops | OPS | `company-ops` |
 | Punk Code Landing | PUNK | `punk-code-landing-page` |
 
-## Regras de trabalho
+## Obrigatório — vínculo com Jira
 
-1. Consultar e atualizar issues **PUNK-*** existentes antes de criar novas (há histórico de branches `PUNK-*` no Git).
-2. Ao avançar fases, mover no Jira via Atlassian MCP (`transitionJiraIssue`).
-3. Fluxo: **Aberta → Desenvolvimento → Teste → Concluido**.
-4. Usar sempre o projeto **PUNK** neste repositório.
+1. **Toda modificação de código** (feature, fix, refactor, docs normativos, CI, config de produto) **deve estar vinculada** a uma issue Jira do tipo **Tarefa** ou **Bug** (ou História quando for o entregável).
+2. **Antes de alterar código:** pesquisar issues existentes no projeto **PUNK**. Reutilizar a issue adequada.
+3. **Se não houver issue:** criar imediatamente no projeto **PUNK**, com summary claro, e só então implementar.
+4. Commits e PRs devem citar a key (ex.: `PUNK-123`).
+5. Não concluir trabalho “só no Git” — atualizar o status no Jira.
+
+## Hierarquia de issues
+
+```text
+Epic
+ └── História (Story)
+      ├── Tarefa (Task)
+      └── Bug
+```
+
+- **Epic:** tema/marco grande.
+- **História (Story):** entrega de valor.
+- **Tarefa (Task):** trabalho técnico concreto sob uma História/Epic.
+- **Bug:** defeito; liga-se a Epic/História (parent/link).
+
+Ao criar Tarefa/Bug, preferir **parent** = História (ou Epic se ainda não houver História).
+
+## Fluxo de status (obrigatório)
+
+```text
+Backlog → Aberta → Desenvolvimento ⇄ Teste → Concluída
+```
+
+| Transição | Quando |
+|---|---|
+| → **Backlog** | Planejado, sem compromisso de execução |
+| → **Aberta** | Pronta para começar |
+| → **Desenvolvimento** | Ao iniciar implementação |
+| → **Teste** | Dev feito; aguarda QA (pode voltar a Desenvolvimento) |
+| → **Concluída** | Validação OK |
+
+- `Desenvolvimento ⇄ Teste` é bidirecional.
+- Não saltar para **Concluída** sem **Teste** (exceto chore/bug trivial com comentário na issue).
+- Usar Atlassian MCP (`transitionJiraIssue`) ou API.
+
+## Checklist do agente (cada lote)
+
+1. Usar projeto **PUNK**.
+2. Encontrar ou **criar** Tarefa/Bug (parent História/Epic se faltar).
+3. Mover para **Desenvolvimento** antes de codar.
+4. Implementar + testes.
+5. Mover para **Teste**; após validação → **Concluída**.
+6. Citar a key no commit/PR.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Adiciona `.cursor/rules/jira-projetos-organizacionais.mdc` alinhando este repo à key **PUNK** (histórico de branches `PUNK-*`) e ao fluxo Jira padrão.

Fonte canônica: `company-ops`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68aa3d7c-6b66-435f-a598-9074a7e5978e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68aa3d7c-6b66-435f-a598-9074a7e5978e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

